### PR TITLE
Address TODOs in the installation guides

### DIFF
--- a/content/documentation/pages/1-installation/1-local/1-docker.md
+++ b/content/documentation/pages/1-installation/1-local/1-docker.md
@@ -16,7 +16,7 @@ Alternatively, you can follow the [manual installation steps](%currentPath%/inst
 
 Download the Spring Cloud Data Flow Server Docker Compose file:
 
-```
+```bash
 wget https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/%dataflow-version%/spring-cloud-dataflow-server/docker-compose.yml
 ```
 
@@ -39,7 +39,7 @@ The Docker Compose file will start up the following:
 
 In the directory where you downloaded `docker-compose.yml`, start the system, as follows:
 
-```
+```bash
 export DATAFLOW_VERSION=%local-server-image-tag%
 export SKIPPER_VERSION=%skipper-version%
 docker-compose up
@@ -60,7 +60,7 @@ The preceding commands first set the `DATAFLOW_VERSION`, `SKIPPER_VERSION` to us
 
 You can also use a shorthand version that exposes only the `DATAFLOW_VERSION`, `SKIPPER_VERSION` variables to the `docker-compose` process (rather than setting it in the environment), as follows:
 
-```
+```bash
 DATAFLOW_VERSION=%local-server-image-tag% SKIPPER_VERSION=%skipper-version% docker-compose up
 ```
 
@@ -83,14 +83,16 @@ In your browser, navigate to the [Spring Cloud Data Flow Dashboard URL](http://l
 
 When you want to shut down Data Flow use the `docker-compose down` command.
 
-1.  Open a new terminal window.
+1. Open a new terminal window.
 
-2.  Change directory to the directory in which you started (where the
-    `docker-compose.yml` file is located).
+1. Change directory to the directory in which you started (where the
+   `docker-compose.yml` file is located).
 
-3.  Run the following command:
+1. Run the following command:
 
-        $ DATAFLOW_VERSION=%local-server-image-tag% SKIPPER_VERSION=%skipper-version% docker-compose down
+```bash
+DATAFLOW_VERSION=%local-server-image-tag% SKIPPER_VERSION=%skipper-version% docker-compose down
+```
 
 <!--NOTE-->
 
@@ -108,22 +110,23 @@ The shell supports tab completion for commands and also for stream/task applicat
 If you have started Data Flow using Docker compose, the shell is is also included in the springcloud/spring-cloud-dataflow-server Docker image.
 To use it, open another console window and type the following:
 
-    $ docker exec -it dataflow-server java -jar shell.jar
+```bash
+docker exec -it dataflow-server java -jar shell.jar
+```
 
 If you have started the Data Flow server via `java -jar`, download and start the shell using the following commands:
 
-1.  Download the Spring Cloud Data Flow Shell application by using the following command:
+Download the Spring Cloud Data Flow Shell application by using the following command:
 
-        wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{%dataflow-version%}/spring-cloud-dataflow-shell-{%dataflow-version%}.jar
+```bash
+wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{%dataflow-version%}/spring-cloud-dataflow-shell-{%dataflow-version%}.jar
+```
 
-**TODO add link/create content for shell**
-Using Spring Cloud Data Flow Shell is further described in
-[Shell](#shell).
+<!-- **TODO add link/create content for shell** -->
 
 ## Monitoring
 
 By default, the Data Flow `docker-compose` configures Stream monitoring with Prometheus and pre-built dashboards for Grafana.
 See the section [Using InfluxDB instead of Prometheus](%currentPath%/installation/local/docker-customize/#using-influxdb-instead-of-prometheus-for-monitoring) to how to perform an InfluxDB based installation.
 
-**TODO Include some screen shots of dashboard**
-**TODO Provide some 'next step' links to getting started task/stream**
+To further learn more about the monitoring experience in SCDF with Prometheus and InfluxDB, please refer to the [Stream Monitoring](%currentPath%/feature-guides/streams/monitoring#local) feature guide.

--- a/content/documentation/pages/1-installation/1-local/2-docker-customize.md
+++ b/content/documentation/pages/1-installation/1-local/2-docker-customize.md
@@ -50,8 +50,8 @@ You can use RabbitMQ rather than Kafka for communication. To do so:
 
 4.  Modify the `app-import` service definition `command` attribute to
     replace
-    `https://bit.ly/Einstein-SR2-stream-applications-kafka-maven` with
-    `https://bit.ly/Einstein-SR2-stream-applications-rabbit-maven`.
+    `https://dataflow.spring.io/kafka-maven-latest` with
+    `https://dataflow.spring.io/rabbitmq-maven-latest`.
 
 ## Using InfluxDB Instead of Prometheus
 

--- a/content/documentation/pages/1-installation/1-local/3-manual.md
+++ b/content/documentation/pages/1-installation/1-local/3-manual.md
@@ -10,28 +10,30 @@ If Docker does not suit your needs, you can manually install the parts you need 
 
 ## Download server jars
 
-1.  Download the Spring Cloud Data Flow Server and shell by using the following command:
+1.  Download the Spring Cloud Data Flow Server and shell by using the following commands:
 
         wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-server/{%dataflow-version%}/spring-cloud-dataflow-server-{%dataflow-version%}.jar
 
         wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{%dataflow-version%}/spring-cloud-dataflow-shell-{%dataflow-version%}.jar
 
-2.  Download [Skipper](https://cloud.spring.io/spring-cloud-skipper/) (because
-    Data Flow delegates to Skipper for those features), by running the
+2.  Download [Skipper](https://cloud.spring.io/spring-cloud-skipper/) by running the
     following commands:
 
-        wget https://repo.spring.io/{skipper-version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-server/%skipper-version%/spring-cloud-skipper-server-%skipper-version%.jar
+        wget https://repo.spring.io/%skipper-version%/org/springframework/cloud/spring-cloud-skipper-server/%skipper-version%/spring-cloud-skipper-server-%skipper-version%.jar
 
 ## Install messaging middleware
 
-These instructions require that RabbitMQ be running on the same machine as Skipper and the Spring Cloud Data Flow server and shell.
+These instructions require that RabbitMQ be running on the same machine as Skipper, Spring Cloud Data Flow server and Shell.
 
-**TODO give references to a docker file and/or install instructions for kafka/rabbitmq**
+To install and run RabbitMQ docker image:
+
+```bash
+docker run -d --hostname rabbitmq --name rabbitmq -p 15672:15672 rabbitmq:3.7.14-management
+```
 
 ## Start server jars
 
-1.  Start Skipper (required unless the Stream features are disabled and
-    the Spring Cloud Data Flow runs in Task mode only). To do so, in the
+1.  Start Skipper. To do so, in the
     directory where you downloaded Skipper, run the server by using
     `java -jar`, as follows:
 
@@ -52,20 +54,16 @@ These instructions require that RabbitMQ be running on the same machine as Skipp
 
         java -jar spring-cloud-dataflow-server-{%dataflow-version%}.jar --spring.cloud.skipper.client.serverUri=https://192.51.100.1:7577/api
 
-    If you want to use the shell to use Data Flow, start it with the following command:
+3.  If you want to use the shell to use Data Flow, start it with the following command:
 
-        java -jar spring-cloud-dataflow-shell-{%dataflow-version%}.jar
+         java -jar spring-cloud-dataflow-shell-{%dataflow-version%}.jar
 
-If the Data Flow Server and shell are not running on the same host, you can also point the shell to the Data Flow server URL by using the
-`dataflow config server` command when in the shell’s interactive mode.
+    If the Data Flow Server and shell are not running on the same host, you can also point the shell to the Data Flow server URL by using the `dataflow config server` command in Shell.
 
-If the Data Flow Server and shell are not running on the same host, point the shell to the Data Flow server URL, as the following example
-shows:
+         server-unknown:>dataflow config server https://198.51.100.0
+         Successfully targeted https://198.51.100.0
 
-    server-unknown:>dataflow config server https://198.51.100.0
-    Successfully targeted https://198.51.100.0
-
-Alternatively, you can pass in the `--dataflow.uri` command line option. The shell’s `--help` command line option shows what is available.
+    Alternatively, you can pass in the `--dataflow.uri` command line option. The shell’s `--help` command line option shows what is available.
 
 [[tip | Proxy Servers]]
 | If you run Spring Cloud Data Flow Server behind a proxy server (such
@@ -82,7 +80,8 @@ Flow Dashboard URL](http://localhost:9393/dashboard).
 
 ## Register pre-built applications
 
-**TODO feels like this can go in some generic section**
+<!-- **TODO feels like this can go in some generic section** -->
+
 All the pre-built streaming applications:
 
 - Are available as Apache Maven artifacts or Docker images.
@@ -90,20 +89,18 @@ All the pre-built streaming applications:
 - Support monitoring via Prometheus and InfluxDB.
 - Contain metadata for application properties used in the UI and code completion in the shell.
 
-Applications can be registered individually using the `app register` functionality or as a group using the `app import` functionality.
-There are also `bit.ly` links that represent the group of pre-built applications for a specific release which is useful for getting started.
+Applications can be registered individually using the `app register` command or in bulk using the `app import` command.
+There are also bulk-registration links that represent the group of pre-built applications for a specific release which is useful for getting started.
 
 You can register applications using the UI or the shell.
-Even though we are only using two pre-built applications, we will register the full set of pre-built applications.
 
-Depending on if you are using RabbitMQ or Kafka, register the applications using the following URL.
+Depending on if you are using RabbitMQ or Kafka, register the applications using the respective URLs.
 
-- Kafka - http://bit.ly/Einstein-SR2-stream-applications-kafka-maven
-- RabbitMQ - http://bit.ly/Einstein-SR2-stream-applications-rabbit-maven
+- Kafka - http://dataflow.spring.io/kafka-maven-latest
+- RabbitMQ - http://dataflow.spring.io/rabbitmq-maven-latest
 
-**TODO screen shot instead of shell command**
+From the Data Flow Shell, you can bulk import and register the applications. For example:
 
-```
-http://bit.ly/Einstein-SR2-stream-applications-kafka-maven
-
+```bash
+dataflow:>app import --uri http://dataflow.spring.io/kafka-maven-latest
 ```

--- a/content/documentation/pages/1-installation/1-local/3-manual.md
+++ b/content/documentation/pages/1-installation/1-local/3-manual.md
@@ -12,9 +12,9 @@ If Docker does not suit your needs, you can manually install the parts you need 
 
 1.  Download the Spring Cloud Data Flow Server and shell by using the following commands:
 
-        wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-server/{%dataflow-version%}/spring-cloud-dataflow-server-{%dataflow-version%}.jar
+        wget https://repo.spring.io/%dataflow-version%/org/springframework/cloud/spring-cloud-dataflow-server/{%dataflow-version%}/spring-cloud-dataflow-server-%dataflow-version%.jar
 
-        wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{%dataflow-version%}/spring-cloud-dataflow-shell-{%dataflow-version%}.jar
+        wget https://repo.spring.io/%dataflow-version%/org/springframework/cloud/spring-cloud-dataflow-shell/{%dataflow-version%}/spring-cloud-dataflow-shell-%dataflow-version%.jar
 
 2.  Download [Skipper](https://cloud.spring.io/spring-cloud-skipper/) by running the
     following commands:
@@ -45,18 +45,18 @@ docker run -d --hostname rabbitmq --name rabbitmq -p 15672:15672 rabbitmq:3.7.14
     downloaded Data Flow, run the server by using `java -jar`, as
     follows:
 
-        java -jar spring-cloud-dataflow-server-{%dataflow-version%}.jar
+        java -jar spring-cloud-dataflow-server-%dataflow-version%.jar
 
     If Skipper and the Data Flow server are not running on the same
     host, set the `spring.cloud.skipper.client.serverUri` configuration
     property to the location of Skipper, as shown in the following
     example
 
-        java -jar spring-cloud-dataflow-server-{%dataflow-version%}.jar --spring.cloud.skipper.client.serverUri=https://192.51.100.1:7577/api
+        java -jar spring-cloud-dataflow-server-%dataflow-version%.jar --spring.cloud.skipper.client.serverUri=https://192.51.100.1:7577/api
 
 3.  If you want to use the shell to use Data Flow, start it with the following command:
 
-         java -jar spring-cloud-dataflow-shell-{%dataflow-version%}.jar
+         java -jar spring-cloud-dataflow-shell-%dataflow-version%.jar
 
     If the Data Flow Server and shell are not running on the same host, you can also point the shell to the Data Flow server URL by using the `dataflow config server` command in Shell.
 
@@ -102,5 +102,5 @@ Depending on if you are using RabbitMQ or Kafka, register the applications using
 From the Data Flow Shell, you can bulk import and register the applications. For example:
 
 ```bash
-dataflow:>app import --uri http://dataflow.spring.io/kafka-maven-latest
+dataflow:>app import --uri https://dataflow.spring.io/kafka-maven-latest
 ```

--- a/content/documentation/pages/1-installation/2-cloudfoundry/1-cf-cli.md
+++ b/content/documentation/pages/1-installation/2-cloudfoundry/1-cf-cli.md
@@ -202,6 +202,17 @@ Once you are ready with the relevant properties in your manifest file,
 you can issue a `cf push` command from the directory where this file is
 stored.
 
+## Shell
+
+The following example shows how to start the Data Flow Shell:
+
+    java -jar spring-cloud-dataflow-shell-{scdf-core-version}.jar
+
+Since the Data Flow Server and shell are not running on the same host, you can point the shell to the Data Flow server URL by using the `dataflow config server` command in Shell.
+
+        server-unknown:>dataflow config server https://<data-flow-server-route-in-cf>
+        Successfully targeted https://<data-flow-server-route-in-cf>
+
 ### Register pre-built applications
 
 All the pre-built streaming applications:
@@ -212,27 +223,12 @@ All the pre-built streaming applications:
 - Contain metadata for application properties used in the UI and code completion in the shell.
 
 Applications can be registered individually using the `app register` functionality or as a group using the `app import` functionality.
-There are also `bit.ly` links that represent the group of pre-built applications for a specific release which is useful for getting started.
+There are also `dataflow.spring.io` links that represent the group of pre-built applications for a specific release which is useful for getting started.
 
 You can register applications using the UI or the shell.
-Even though we are only using two pre-built applications, we will register the full set of pre-built applications.
 
 Since the Cloud Foundry installation guide uses RabbitMQ as the messaging middleware, register the RabbitMQ version of the applications.
 
-**TODO screen shot instead of shell command**
-
+```bash
+dataflow:>app import --uri http://dataflow.spring.io/rabbitmq-maven-latest
 ```
-app import --uri  http://bit.ly/Einstein-SR2-stream-applications-rabbit-maven
-```
-
-## Shell
-
-The following example shows how to start the Data Flow Shell:
-
-    $ java -jar spring-cloud-dataflow-shell-{scdf-core-version}.jar
-
-**TODO add info on setting the url of the data flow server when starting**
-
-## Monitoring
-
-**TODO what to say about monitoring??**

--- a/content/documentation/pages/1-installation/2-cloudfoundry/2-cf-local.md
+++ b/content/documentation/pages/1-installation/2-cloudfoundry/2-cf-local.md
@@ -6,8 +6,6 @@ description: 'Configure the local servers to deploy to Cloud Foundry'
 
 Sometimes for debugging purposes it is convenient to run the Data Flow and Skipper server on your local machine and configure it to deploy applications to Cloud Foundry.
 
-**TODO - do we want this guide?**
-
 # Configure Data Flow Server on Local Machine
 
 To run the server application locally (on your laptop or desktop) and target your Cloud Foundry installation, you can configure the Data Flow server by setting the following environment variables in a property file (for example, `myproject.properties`):
@@ -42,14 +40,23 @@ Now you are ready to start the server application, as follows:
 
     java -jar spring-cloud-dataflow-server-{%dataflow-version%}.jar --spring.config.additional-location=<PATH-TO-FILE>/foo.properties
 
-**TODO bad references below**
-
-[[tip]]
-| All other parameterization options that were available when running
-| the server on Cloud Foundry are still available. This is particularly
-| true for [configuring defaults](#configuring-defaults) > [???](#configuring-defaults) for applications. To use them, substitute
-| `cf set-env` syntax with `export`.
-
 # Configure Skipper Server on Local Machine
 
-**TODO **
+To run the Skipper application locally (on your laptop or desktop) and target your Cloud Foundry installation, you can configure the Skipper server by setting the following environment variables in a property file (for example, `myproject.properties`):
+
+    spring.profiles.active=cloud
+    jbp.config.spring.auto.reconfiguration='{enabled: false}'
+    spring.cloud.skipper.server.platform.cloudfoundry.accounts[default].connection.url=https://api.run.pivotal.io
+    spring.cloud.skipper.server.platform.cloudfoundry.accounts[default].connection.org={org}
+    spring.cloud.skipper.server.platform.cloudfoundry.accounts[default].connection.space={space}
+    spring.cloud.skipper.server.platform.cloudfoundry.accounts[default].connection.domain=cfapps.io
+    spring.cloud.skipper.server.platform.cloudfoundry.accounts[default].connection.username={email}
+    spring.cloud.skipper.server.platform.cloudfoundry.accounts[default].connection.password={password}
+    spring.cloud.skipper.server.platform.cloudfoundry.accounts[default].connection.skipSslValidation=false
+
+You need to fill in `\{org}`, `\{space}`, `\{email}`, and `\{password}` before using the file in the following command.
+
+[[warning | SSL Validation]]
+| Set _Skip SSL Validation_ to true only if you run on a Cloud Foundry
+| instance by using self-signed certificates (for example, in
+| development). Do not use self-signed certificates for production.

--- a/content/documentation/pages/1-installation/2-cloudfoundry/2-cf-local.md
+++ b/content/documentation/pages/1-installation/2-cloudfoundry/2-cf-local.md
@@ -38,7 +38,7 @@ You need to fill in `\{org}`, `\{space}`, `\{email}`, and `\{password}` before u
 
 Now you are ready to start the server application, as follows:
 
-    java -jar spring-cloud-dataflow-server-{%dataflow-version%}.jar --spring.config.additional-location=<PATH-TO-FILE>/foo.properties
+    java -jar spring-cloud-dataflow-server-%dataflow-version%.jar --spring.config.additional-location=<PATH-TO-FILE>/foo.properties
 
 # Configure Skipper Server on Local Machine
 

--- a/content/documentation/pages/1-installation/3-kubernetes/1-helm.md
+++ b/content/documentation/pages/1-installation/3-kubernetes/1-helm.md
@@ -193,7 +193,7 @@ All the pre-built streaming applications:
 - Contain metadata for application properties used in the UI and code completion in the shell.
 
 Applications can be registered individually using the `app register` functionality or as a group using the `app import` functionality.
-There are also `bit.ly` links that represent the group of pre-built applications for a specific release which is useful for getting started.
+There are also `dataflow.spring.io` links that represent the group of pre-built applications for a specific release which is useful for getting started.
 
 You can register applications using the UI or the shell.
 Even though we are only using two pre-built applications, we will register the full set of pre-built applications.
@@ -201,10 +201,8 @@ Even though we are only using two pre-built applications, we will register the f
 The easiest way to install Data Flow on Kubernetes is using the Helm chart that uses RabbitMQ as the default messaging middleware.
 The command to import the Kafka version of the applications is
 
-**TODO screen shot instead of shell command**
-
-```
-app import --uri  http://bit.ly/Einstein-SR2-stream-applications-kafka-docker
+```bash
+dataflow:>app import --uri http://dataflow.spring.io/kafka-docker-latest
 ```
 
 Change `kafka` to `rabbit` in the above URL if you set `kafka.endabled=true` in the helm chart or followed the manual `kubectl` based installation instructions for installing Data Flow on Kubernetes and chose to use Kafka as the messaging middleware.
@@ -730,4 +728,4 @@ shows:
 
 ## Monitoring
 
-**TODO where do we discuss monitoring deployed apps on k8s??**s
+To learn more about the monitoring experience in SCDF using Prometheus running on Kubernetes, please refer to the [Stream Monitoring](%currentPath%/feature-guides/streams/monitoring/#kubernetes) feature guide.

--- a/content/documentation/pages/5-feature-guides/1-streams/11-monitoring.md
+++ b/content/documentation/pages/5-feature-guides/1-streams/11-monitoring.md
@@ -119,7 +119,7 @@ Start the Skipper server. Then start the Data Flow server with the following pro
 Now if you deploy a simple stream that uses Kafka, such as
 
 ```bash
-dataflow:>app import --uri http://bit.ly/Einstein-SR2-stream-applications-kafka-maven --force
+dataflow:>app import --uri http://dataflow.spring.io/kafka-maven-latest --force
 dataflow:>stream create stream2 --definition "time --fixed-delay=10 --time-unit=MILLISECONDS | filter --expression=payload.contains('3') | log" --deploy
 ```
 
@@ -209,7 +209,7 @@ Start the Skipper server. Then start the Data Flow server with the following pro
 Now if you deploy a simple stream that uses Kafka, such as
 
 ```bash
-dataflow:>app import --uri http://bit.ly/Einstein-SR2-stream-applications-kafka-maven --force
+dataflow:>app import --uri http://dataflow.spring.io/kafka-maven-latest --force
 
 dataflow:>stream create stream2 --definition "time --fixed-delay=10 --time-unit=MILLISECONDS | filter --expression=payload.contains('3') | log" --deploy
 ```

--- a/content/documentation/pages/5-feature-guides/1-streams/7-java-dsl.md
+++ b/content/documentation/pages/5-feature-guides/1-streams/7-java-dsl.md
@@ -41,7 +41,7 @@ Consider the following example, using the `definition` style.
 URI dataFlowUri = URI.create("http://localhost:9393");
 DataFlowOperations dataFlowOperations = new DataFlowTemplate(dataFlowUri);
 dataFlowOperations.appRegistryOperations().importFromResource(
-                     "https://bit.ly/%streaming-apps-latest%-stream-applications-rabbit-maven", true);
+                     "https://dataflow.spring.io/%streaming-apps-latest%-stream-applications-rabbit-maven", true);
 StreamDefinition streamDefinition = Stream.builder(dataFlowOperations)
                                       .name("ticktock")
                                       .definition("time | log")
@@ -169,7 +169,7 @@ You can register your application by using the `DataFlowTemplate`, as follows:
 
 ```java
 dataFlowOperations.appRegistryOperations().importFromResource(
-            "https://bit.ly/%streaming-apps-latest%-stream-applications-rabbit-maven", true);
+            "https://dataflow.spring.io/%streaming-apps-latest%-stream-applications-rabbit-maven", true);
 ```
 
 The Stream applications can also be beans within your application that are injected in other classes to create Streams.

--- a/content/documentation/pages/6-recipes/1-polyglot/1-polyglot-python-processor.md
+++ b/content/documentation/pages/6-recipes/1-polyglot/1-polyglot-python-processor.md
@@ -114,7 +114,7 @@ dataflow config server --uri <Your Data Flow URL>
 Import the SCDF app starters and register the `polyglot-python-processor` as `python-processor` of type `processor`.
 
 ```bash
-app import --uri http://bit.ly/Einstein-SR2-stream-applications-kafka-docker
+app import --uri http://dataflow.spring.io/kafka-docker-latest
 app register --type processor --name python-processor --uri springcloud/polyglot-python-processor:0.1
 ```
 

--- a/content/documentation/pages/6-recipes/1-polyglot/3-polyglot-python-app.md
+++ b/content/documentation/pages/6-recipes/1-polyglot/3-polyglot-python-app.md
@@ -134,7 +134,7 @@ dataflow config server --uri http://192.168.99.100:30868`
 Import the SCDF app starters and register the polyglot-python-app as barista-app of type `app`
 
 ```bash
-app import --uri http://bit.ly/Einstein-SR2-stream-applications-kafka-docker
+app import --uri http://dataflow.spring.io/kafka-docker-latest
 app register --type app --name barista-app --uri docker://springcloud/polyglot-python-app:0.1
 ```
 

--- a/content/documentation/variables.json
+++ b/content/documentation/variables.json
@@ -1,7 +1,7 @@
 {
   "version": "v2.0.1.RELEASE",
-  "task-app-maven-version": "http://bit.ly/Elston-GA-task-applications-maven",
-  "task-app-docker-version": "http://bit.ly/Elston-GA-task-applications-docker",
+  "task-app-maven-version": "http://dataflow.spring.io/task-maven-latest",
+  "task-app-docker-version": "http://dataflow.spring.io/task-docker-latest",
   "thing1": "thing1",
   "thing2": {
     "thing1": "thing2"


### PR DESCRIPTION
Address TODOs where possible in the installation guides; comment the items that aren't required for MVP (2 of them still remains).

Replace all bit.ly references with dataflow.spring.io URLs.

Update subtle UX corrections.