### PR TITLE
Fix remaining TODOs

### DIFF
--- a/content/documentation/pages/3-stream-developer-guides/2-streams/2-standalone-stream-kafka.md
+++ b/content/documentation/pages/3-stream-developer-guides/2-streams/2-standalone-stream-kafka.md
@@ -546,10 +546,6 @@ Now, you can see that this application logs the usage cost detail.
 
 This section will walk you through how to deploy the `UsageDetailSender`, `UsageCostProcessor` and `UsageCostLogger` applications on CloudFoundry.
 
-#### Create Kafka Cloud Foundry User Provided service
-
-**TODO**
-
 #### Create CF manifest for UsageDetail Sender
 
 Create a CF manifest yaml `usage-detail-sender.yml` file for the `UsageDetailSender` using its configuration properties:

--- a/content/documentation/pages/3-stream-developer-guides/2-streams/3-data-flow-stream.md
+++ b/content/documentation/pages/3-stream-developer-guides/2-streams/3-data-flow-stream.md
@@ -80,8 +80,6 @@ When you register an application, you provide:
 
 Let's assume you are running Spring Cloud Data Flow, Skipper servers running on your local development environment.
 
-**TODO - the images are too small to see what to type.....**
-
 Register the `UsageDetailSender` source application:
 
 From the Applications view, select `Add Application(s)`.
@@ -89,9 +87,13 @@ This will display a view to allow you to register applications.
 
 Register the `maven` artifact of the `UsageDetailSender` application with the name `usage-detail-sender`:
 
+> (uri = `maven://io.spring.dataflow.sample:usage-detail-sender-rabbit:0.0.1-SNAPSHOT`)
+
 ![Register source application maven](images/SCDF-register-source-rabbit.png)
 
 If you are using a `docker` artifact, then
+
+> (uri = `docker://springcloudstream/usage-detail-sender-rabbit:0.0.1-SNAPSHOT`)
 
 ![Register source application docker](images/SCDF-register-source-rabbit-docker.png)
 
@@ -101,17 +103,25 @@ Click on `New application` to display another instance of the form to enter the 
 
 Register the `maven` artifact of the `UsageCostProcessor` processor application with the name `usage-cost-processor`:
 
+> (uri = `maven://io.spring.dataflow.sample:usage-cost-processor-rabbit:0.0.1-SNAPSHOT`)
+
 ![Register source application maven](images/SCDF-register-processor-rabbit.png)
 
 If you are using a `docker` artifact, then
+
+> (uri = `docker://springcloudstream/usage-cost-processor-rabbit:0.0.1-SNAPSHOT`)
 
 ![Register source application docker](images/SCDF-register-processor-rabbit-docker.png)
 
 Register the `maven` artifact of the `UsageCostLogger` sink application with the name `usage-cost-logger`
 
+> (uri = `maven://io.spring.dataflow.sample:usage-cost-logger-rabbit:0.0.1-SNAPSHOT`)
+
 ![Register sink application maven](images/SCDF-register-sink-rabbit.png)
 
 If you are using a `docker` artifact, then
+
+> (uri = `docker://springcloudstream/usage-cost-logger-rabbit:0.0.1-SNAPSHOT`)
 
 ![Register source application docker](images/SCDF-register-sink-rabbit-docker.png)
 

--- a/content/documentation/pages/5-feature-guides/1-streams/8-tap.md
+++ b/content/documentation/pages/5-feature-guides/1-streams/8-tap.md
@@ -6,7 +6,7 @@ description: 'Create a stream from another stream without interrupting the data 
 
 # Tapping a Stream
 
-**TODO Review**
+<!-- **TODO Review** -->
 
 In Spring Cloud Stream terms, a named destination is a specific destination name in the messaging middleware or the streaming platform.
 It could be an `exchange` in RabbitMQ or a `topic` in Apache Kafka.


### PR DESCRIPTION
It wasn't easy to plug the Kafka CUPs in the existing content. It has to be reworked to prepare for CUPs, so I removed it. The CUPs, in general, can be a section in recipes eventually.

Attempt to fix the screenshot/URI TODO - not sure if it is elegant, though.

With that, no other addressable TODOs remain.