### PR TITLE
Remove bogus config docs from k8s installation

### DIFF
--- a/content/documentation/pages/1-installation/3-kubernetes/1-helm.md
+++ b/content/documentation/pages/1-installation/3-kubernetes/1-helm.md
@@ -291,7 +291,7 @@ override global server level properties on a per-application basis.
 <!--END_TIP-->
 
 Properties to be applied for all deployed Tasks are defined in the
-`src/kubernetes/server/server-config-(binder).yaml` file and for Streams
+`src/kubernetes/server/server-config.yaml` file and for Streams
 in `src/kubernetes/skipper/skipper-config-(binder).yaml`. Replace
 `(binder)` with the messaging middleware you are using — for example,
 `rabbit` or `kafka`.

--- a/content/documentation/pages/1-installation/3-kubernetes/2-kubectl.md
+++ b/content/documentation/pages/1-installation/3-kubernetes/2-kubectl.md
@@ -147,7 +147,7 @@ afterwards.
 
 <!--TIP-->
 
-You should replace the `url` attribute value shown in the following example in `src/kubernetes/server/server-config-rabbit.yaml` or `src/kubernetes/server/server-config-kafka.yaml` to reflect the address and port Grafana is running on.
+You should replace the `url` attribute value shown in the following example in `src/kubernetes/server/server-config.yaml` to reflect the address and port Grafana is running on.
 On Minikube, you can obtain the value by running the command `minikube service --url grafana`.
 This configuration is needed for Grafana links to be accessible when accessing the dashboard from a web browser.
 
@@ -164,8 +164,7 @@ a password of `password`. You can change these defaults by modifying the
 
 In the event that you would not like to deploy metrics collection by
 using Prometheus and Grafana, you should remove the following section of
-`src/kubernetes/server/server-config-rabbit.yaml` or
-`src/kubernetes/server/server-config-kafka.yaml`. You can edit the
+`src/kubernetes/server/server-config.yaml`. You can edit the
 appropriate file based on the messaging middleware deployed earlier:
 
 ```yml
@@ -307,29 +306,14 @@ the [Spring Cloud Kubernetes library](https://github.com/spring-cloud/spring-clo
 [`ConfigMap`](https://kubernetes.io/docs/user-guide/configmap/) and
 [`Secrets`](https://kubernetes.io/docs/user-guide/secrets/) settings.
 
-The `ConfigMap` settings for RabbitMQ are specified in the `src/kubernetes/server/server-config-rabbit.yaml` file and for Kafka in
-the `src/kubernetes/server/server-config-kafka.yaml` file.
+The `ConfigMap` settings for RabbitMQ are specified in the `src/kubernetes/skipper/skipper-config-rabbit.yaml` file and for Kafka in
+the `src/kubernetes/skipper/skipper-config-kafka.yaml` file.
 
 MySQL secrets are located in the `src/kubernetes/mysql/mysql-secrets.yaml` file.
 If you modified the password for MySQL, you should change it in the `src/kubernetes/mysql/mysql-secrets.yaml` file.
 Any secrets have to be provided in base64 encoding.
 
-<!--NOTE-->
-
-We configure the Data Flow server using file-based security. The default user is _user_ with a password of _password_.
-
-You should change these values in `src/kubernetes/server/server-config-rabbit.yaml` for RabbitMQ or `src/kubernetes/server/server-config-kafka.yaml` for Kafka.
-
-<!--END_NOTE-->
-
-To create the configuration map when using RabbitMQ, run the following
-command:
-
-```
-kubectl create -f src/kubernetes/server/server-config-rabbit.yaml
-```
-
-To create the configuration map when using Kafka, run the following
+To create the configuration map with the default settings, run the following
 command:
 
 ```

--- a/content/documentation/pages/5-feature-guides/1-streams/11-monitoring.md
+++ b/content/documentation/pages/5-feature-guides/1-streams/11-monitoring.md
@@ -224,7 +224,7 @@ You should see dashboards similar to these.
 
 Prometheus is a popular pull based time series database that pulls metrics from the target applications from a pre-configured endpoint. When running in Kubernetes, Prometheus will "scrape" metrics from target applications that have specific pod level annotation. The endpoint to scrape is provided by Spring Boot, under the default path of `/actuator/prometheus`.
 
-Out of the box, each binder middleware configuration file defines attributes to enable metrics and supporting properties. Settings for RabbitMQ can be found in: `src/kubernetes/server/server-config-rabbit.yaml` and `src/kubernetes/server/server-config-kafka.yaml` for Kafka. The main point of interest is the following configuration section:
+Out of the box, each binder middleware configuration file defines attributes to enable metrics and supporting properties. Settings can be found in: `src/kubernetes/server/server-config.yaml`. The main point of interest is the following configuration section:
 
 ```yaml
 applicationProperties:


### PR DESCRIPTION
The following wrong instructions are addressed in this PR.

- Replace and remove all references to `src/kubernetes/server/server-config-kafka.yaml` and `src/kubernetes/server/server-config-rabbit.yaml` - we only have 1 YAML for SCDF

- Update instructions to point to Skipper's rabbit and kafka YAMLs where relevant

- Remove bogus entry re: file-based authentication as the default setting

