### PR TITLE
Add missing FAQs

### DIFF
--- a/content/documentation/pages/3-stream-developer-guides/5-troubleshooting/2-debugging-scdf-streams.md
+++ b/content/documentation/pages/3-stream-developer-guides/5-troubleshooting/2-debugging-scdf-streams.md
@@ -33,11 +33,11 @@ graph TD;
 Application log files can be inspected on a per application basis.
 To aggregate logs from all applications into one, the deployer property `inheritLogging=true` can be set.
 See
-[Log Redirect](https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#_log_redirect)
-for more information and [Deployment Logs](https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#troubleshooting-deployment-logs) for enabling more log output.
+["Is it possible to aggregate Local deployments into a single log?"](%currentPath%/resources/faq/)
+for more information and ["How do I enable DEBUG logs for platform deployments?"](%currentPath%/resources/faq/) for enabling more log output.
 
 Debugging applications via JDWP can be accomplished by setting the deployer property `debugPort`.
-See [Remote Debugging](https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#_remote_debugging) for more information.
+See [How do I remote debug deployed applications?](%currentPath%/resources/faq/) for more information.
 
 ### Docker Compose - Startup
 
@@ -49,7 +49,7 @@ graph TD;
 ```
 
 The environment variables `DATAFLOW_VERSION` and `SKIPPER_VERSION` must be available in the current terminal environment via `export` or prefixing the `docker-compose` command.
-See [Starting Docker Compose](https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#getting-started-local-deploying-spring-cloud-dataflow-docker-starting) for more information.
+See [Starting Docker Compose](%currentPath%/installation/local/docker/) for more information.
 
 ### Docker Compose - Runtime
 
@@ -97,7 +97,7 @@ graph TD;
 ```
 
 When debugging deployment issues, raising deployer and Cloud Foundry related log levels may be useful.
-See [Deployment Logs](https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#troubleshooting-deployment-logs) for more information.
+See ["How do I enable DEBUG logs for platform deployments?"](%currentPath%/resources/faq/) for more information.
 
 ## Kubernetes
 

--- a/content/documentation/pages/4-batch-developer-guides/2-batch/1-simple-task.md
+++ b/content/documentation/pages/4-batch-developer-guides/2-batch/1-simple-task.md
@@ -497,4 +497,4 @@ kubectl delete all -l app=mysql
 
 ## What's Next
 
-Congratulations you have just created and deployed a Spring Cloud Task application. Now lets go onto the [next section](/documentation/master/batch-developer-guides/batch/spring-batch/) and create a Spring Batch Application.
+Congratulations you have just created and deployed a Spring Cloud Task application.

--- a/content/documentation/pages/4-batch-developer-guides/3-troubleshooting/2-debugging-scdf-tasks.md
+++ b/content/documentation/pages/4-batch-developer-guides/3-troubleshooting/2-debugging-scdf-tasks.md
@@ -52,8 +52,8 @@ graph TD;
 Application log files can be inspected on a per application basis.
 To aggregate logs from all applications into one, the deployer property `inheritLogging=true` can be set.
 See
-[Log Redirect](https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#_log_redirect)
-for more information and [Deployment Logs](https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#troubleshooting-deployment-logs) for enabling more log output.
+["Is it possible to aggregate Local deployments into a single log?"](%currentPath%/resources/faq/)
+for more information and ["How do I enable DEBUG logs for platform deployments?"](%currentPath%/resources/faq/) for enabling more log output.
 
 Debugging applications via JDWP can be accomplished by setting the deployer property `debugPort`.
 See [Remote Debugging](https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#_remote_debugging) for more information.
@@ -68,7 +68,7 @@ graph TD;
 ```
 
 The environment variables `DATAFLOW_VERSION` and `SKIPPER_VERSION` must be available in the current terminal environment via `export` or prefixing the `docker-compose` command.
-See [Starting Docker Compose](https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#getting-started-local-deploying-spring-cloud-dataflow-docker-starting) for more information.
+See [Starting Docker Compose](%currentPath%/installation/local/docker/) for more information.
 
 #### Docker Compose - Runtime
 
@@ -113,7 +113,7 @@ graph TD;
 ```
 
 When debugging deployment issues, raising deployer and Cloud Foundry related log levels may be useful.
-See [Deployment Logs](https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#troubleshooting-deployment-logs) for more information.
+See ["How do I enable DEBUG logs for platform deployments?"](%currentPath%/resources/faq/) for more information.
 
 ### Kubernetes
 

--- a/content/documentation/pages/7-resources/3-faq.md
+++ b/content/documentation/pages/7-resources/3-faq.md
@@ -314,7 +314,7 @@ Also, when there is more then one instance of the application, the debug port fo
 
 <!--END_QUESTION-->
 
-<!--QUESTION-->
+<!--QUESTION#anchor-sample-->
 
 Is it possible to aggregate Local deployments into a single log?
 

--- a/plugins/spring-remark-question/gatsby-browser.js
+++ b/plugins/spring-remark-question/gatsby-browser.js
@@ -13,3 +13,15 @@ exports.onClientEntry = () => {
     }
   }
 }
+
+exports.onRouteUpdate = ({ location, prevLocation }) => {
+  const hash = window.location.hash.replace('#', '')
+  if (hash) {
+    setTimeout(() => {
+      const block = document.getElementById(hash)
+      if (block && block.className === 'question-block') {
+        block.className = 'question-block active'
+      }
+    }, 100)
+  }
+}

--- a/plugins/spring-remark-question/index.js
+++ b/plugins/spring-remark-question/index.js
@@ -1,4 +1,7 @@
+const get = require(`lodash.get`)
+
 const START_KEY = '<!--QUESTION-->'
+const KEY = /^(<!--QUESTION#)(.*?)-->/
 const END_KEY = '<!--END_QUESTION-->'
 
 module.exports = ({ markdownAST, markdownNode }, options = {}) => {
@@ -6,11 +9,20 @@ module.exports = ({ markdownAST, markdownNode }, options = {}) => {
 
   for (let i = 0; i < markdownAST.children.length; i++) {
     let node = markdownAST.children[i]
-    if (node.value === START_KEY) {
+    const value = get(node, 'value')
+    if (value && (value === START_KEY || value.match(KEY))) {
       const items = []
       let title
+      let anchor = ''
       i++
       node = markdownAST.children[i]
+
+      if (value.match(KEY)) {
+        anchor = value
+          .replace('<!--QUESTION#', '')
+          .replace('-->', '')
+          .replace(/ /g, '-')
+      }
 
       while (END_KEY !== node.value && i < markdownAST.children.length) {
         if (!title) {
@@ -25,7 +37,7 @@ module.exports = ({ markdownAST, markdownNode }, options = {}) => {
       children.push({
         type: 'element',
         tagName: 'div',
-        data: { hProperties: { className: 'question-block ' } },
+        data: { hProperties: { className: 'question-block', id: anchor } },
         children: [
           {
             type: 'element',

--- a/src/styles/_md.scss
+++ b/src/styles/_md.scss
@@ -439,7 +439,7 @@
     }
     &.active {
       .answer {
-        max-height: 600px;
+        max-height: 1500px;
       }
       .question {
         &:before {


### PR DESCRIPTION
This PR addresses the following issues:

1) Add the missing content to FAQ from the old reference guide (they are removed from 2.1.x ref. guide)

2) Fix all the broken links in the stream/batch troubleshooting

3) Remove a bogus link from the task -> batch developer guide

Resolves https://github.com/spring-io/dataflow.spring.io/issues/76