### PR TITLE
Fixed list of middleware products

### DIFF
--- a/content/documentation/pages/2-concepts/1-architecture.md
+++ b/content/documentation/pages/2-concepts/1-architecture.md
@@ -115,7 +115,7 @@ There are binding libraries for the following messaging middleware products:
 - [Amazon Kinesis](https://aws.amazon.com/kinesis/)
 - [Google Pub/Sub](https://cloud.google.com/pubsub/docs/)
 - [Solace PubSub+](https://solace.com/software/)
-  [Azure Event Hubs](https://azure.microsoft.com/en-us/services/event-hubs/)
+- [Azure Event Hubs](https://azure.microsoft.com/en-us/services/event-hubs/)
 
 [[note]]
 | The Data Flow server delegates to the Skipper server to deploy long-lived applications.


### PR DESCRIPTION
The list of middleware products shows Solace and Azure on the same line. This fix shows them on different lines.