### PR TITLE
Update SCDF, Skipper, Stream and Task versions

### DIFF
--- a/content/documentation/variables.json
+++ b/content/documentation/variables.json
@@ -1,13 +1,13 @@
 {
   "streaming-apps-version": "Einstein.SR3",
   "batch-apps-version": "Elston.RELEASE",
-  "stream-version": "2.1.2.RELEASE",
-  "task-version": "2.1.1.RELEASE",
-  "skipper-version": "2.0.3.RELEASE",
+  "stream-version": "2.2.0.RELEASE",
+  "task-version": "2.1.2.RELEASE",
+  "skipper-version": "2.1.0.RELEASE",
   "skipper-snapshot-version": "2.1.0.BUILD-SNAPSHOT",
-  "dataflow-version": "2.1.2.RELEASE",
+  "dataflow-version": "2.2.0.RELEASE",
   "dataflow-snapshot-version": "2.2.0.BUILD-SNAPSHOT",
-  "github-tag": "v2.1.0.RELEASE",
+  "github-tag": "v2.2.0.RELEASE",
   "task-app-maven-version": "https://dataflow.spring.io/task-maven-latest",
   "task-app-docker-version": "https://dataflow.spring.io/task-docker-latest",
 


### PR DESCRIPTION
Bump to various latest GA release versions.