### PR TITLE
Updated version of timestamp task

### DIFF
--- a/content/documentation/pages/2-concepts/1-architecture.md
+++ b/content/documentation/pages/2-concepts/1-architecture.md
@@ -192,7 +192,7 @@ A task application is registered with Data Flow using the name `task` to describ
 The following example shows the shell syntax for registering a `timestamp` task (an application that prints the current time and exits):
 
 ```
-dataflow:> app register --name timestamp --type task --uri maven://org.springframework.cloud.task.app:timestamp-task:1.3.0.RELEASE
+dataflow:> app register --name timestamp --type task --uri maven://org.springframework.cloud.task.app:timestamp-task:2.1.0.RELEASE
 ```
 
 The task definition is created by referencing the name of the task, as the following example shows:


### PR DESCRIPTION
Trying to run the task being followed by getting started guide I found that version 1.3.0.RELEASE throws error: java.lang.IllegalArgumentException: Delegate listener must not be null

Switching to a new version helped.

So, changing version for this guide to bring less frustration for people who are just starting with the project.