### PR TITLE
Replace flattened env vars in CF manifest with SAJ

### DIFF
--- a/content/documentation/pages/1-installation/2-cloudfoundry/1-cf-cli.md
+++ b/content/documentation/pages/1-installation/2-cloudfoundry/1-cf-cli.md
@@ -85,7 +85,7 @@ To install Cloud Foundry:
     Once you have installed Cloud Foundry, you can push Skipper to
     Cloud Foundry. To do so, you need to create a manifest for Skipper.
 
-    You will use the default deployment platform `deployment.services` setting in the `Skipper Server` configuration, as shown below, to configure Skipper to bind the RabbitMQ service to all deployed streaming applications.
+    You will use the "default" deployment platform `deployment.services` setting in the `Skipper Server` configuration, as shown below, to configure Skipper to bind the RabbitMQ service to all deployed streaming applications. Note "rabbitmq" is the name of the service instance in this case.
 
     The following example shows a typical manifest for Skipper:
 
@@ -107,7 +107,6 @@ To install Cloud Foundry:
           SPRING_APPLICATION_JSON: |-
             {
               "spring.cloud.skipper.server" : {
-                 "strategies.healthcheck.timeoutInMillis" : 300000, 
                  "platform.cloudfoundry.accounts":  {
                        "default": {
                            "connection" : {
@@ -195,7 +194,8 @@ If you need to configure multiple Maven repositories, a proxy, or authorization 
 
 As an alternative to setting environment variables with the `cf set-env` command, you can curate all the relevant environment variables in a
 `manifest.yml` file and use the `cf push` command to provision the server.
-The following example shows such a manifest file:
+
+The following example shows such a manifest file. Note that "postgresSQL" is the name of the database service instance:
 
 ```yml
 ---
@@ -240,7 +240,7 @@ applications:
            }
         }
 services:
-  - postgreSQL
+  - postgresSQL
 ```
 
 <!--TIP-->

--- a/content/documentation/pages/4-batch-developer-guides/2-batch/9-data-flow-simple-task-cloudfoundry.md
+++ b/content/documentation/pages/4-batch-developer-guides/2-batch/9-data-flow-simple-task-cloudfoundry.md
@@ -62,7 +62,7 @@ cf create-service cloudamqp lemur rabbitmq-service
 [[important]]
 | **IMPORTANT**: When choosing a Postgres service, keep an eye on the provided number of connections. On PWS, for example, the free service tier of `elephantsql` provides only four parallel database connections, which is too limiting to successfully run this example.
 
-Make sure you name your PostgresSQL service `postgres-service`. We use that name in the rest of the examples in this document
+Make sure you name your PostgresSQL service `postgres-service`. We use that name in the rest of the examples in this document.
 
 ## Setting up Skipper on Cloud Foundry
 
@@ -91,7 +91,6 @@ This example uses Skipper, which you can set up on Cloud Foundry. To do so:
          SPRING_APPLICATION_JSON: |-
            {
              "spring.cloud.skipper.server" : {
-                "strategies.healthcheck.timeoutInMillis" : 300000, 
                 "platform.cloudfoundry.accounts" : {
                       "default" : {
                           "connection" : {
@@ -105,7 +104,7 @@ This example uses Skipper, which you can set up on Cloud Foundry. To do so:
                           },
                           "deployment" : {
                               "deleteRoutes" : false,
-                              "services" : "rabbitmq",
+                              "services" : "rabbitmq-service",
                               "enableRandomAppNamePrefix" : false,
                               "memory" : 2048
                           }
@@ -163,7 +162,7 @@ This example uses Skipper, which you can set up on Cloud Foundry. To do so:
                                "skipSsValidation" : true 
                            },
                            "deployment" : {
-                             "services" : "postgresSQL, rabbitmq"
+                             "services" : "postgres-service"
                            }
                        }
                    },


### PR DESCRIPTION
This replaces flattened env vars with SAJ for 2 additional pages