### PR TITLE
Revert Kafka deployment's name change

### DIFF
--- a/content/documentation/pages/1-installation/3-kubernetes/2-kubectl.md
+++ b/content/documentation/pages/1-installation/3-kubernetes/2-kubectl.md
@@ -45,8 +45,8 @@ You need to configure only one message broker.
   kubectl create -f src/kubernetes/kafka/
   ```
 
-  You can use `kubectl get all -l app=kafka-broker` to verify that the deployment, pod, and service resources are running.
-  Use `kubectl delete all -l app=kafka-broker` to clean up afterwards.
+  You can use `kubectl get all -l app=kafka` to verify that the deployment, pod, and service resources are running.
+  Use `kubectl delete all -l app=kafka` to clean up afterwards.
 
 ## Deploy Services, Skipper, and Data Flow
 

--- a/content/documentation/pages/3-stream-developer-guides/2-streams/2-standalone-stream-kafka.md
+++ b/content/documentation/pages/3-stream-developer-guides/2-streams/2-standalone-stream-kafka.md
@@ -845,7 +845,7 @@ kubectl delete pod -l app=usage-cost-stream
 To uninstall Kafka, run the following command:
 
 ```bash
-kubectl delete all -l app=kafka-broker
+kubectl delete all -l app=kafka
 ```
 
 ## What's Next


### PR DESCRIPTION
Given that we are reverting back to `wurstmeister/kafka` image in the SCDF + Kafka's K8s deployment, this PR reverts the Kafka's application name to what it was prior to the Confluent switch.

I reverted the Kafka app-specific changes from this commit: https://github.com/spring-io/dataflow.spring.io/commit/7a1da55042d73759faf1709dca76f01eca8f2c7f.