### PR TITLE
Fixed k8s yaml not matching spring version

### DIFF
--- a/content/documentation/pages/4-batch-developer-guides/2-batch/1-simple-task.md
+++ b/content/documentation/pages/4-batch-developer-guides/2-batch/1-simple-task.md
@@ -432,7 +432,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: task
-      image: springcloudtask/billsetuptask:1.0.0.BUILD-SNAPSHOT
+      image: springcloudtask/billsetuptask:0.0.1-SNAPSHOT
       env:
         - name: SPRING_DATASOURCE_PASSWORD
           valueFrom:


### PR DESCRIPTION
The setuptask is created with <version>0.0.1-SNAPSHOT</version>, but the yaml was using 1.0.0.BUILD-SNAPSHOT. This resulted in ErrImagePull when applying the yaml to the kubernetes cluster.