### PR TITLE
Swapping kafka and rabbitmq examples

### DIFF
--- a/content/documentation/pages/5-feature-guides/1-streams/10-function-composition.md
+++ b/content/documentation/pages/5-feature-guides/1-streams/10-function-composition.md
@@ -122,7 +122,7 @@ If you use the RabbitMQ binder, you can download [http-transformer-with-RabbitMQ
 After downloading and unpacking the source code, you can build the application by using Maven, as follows:
 
 ```
-cd composed-http-transformer-kafka
+cd composed-http-transformer-rabbitmq
 ./mvnw clean install
 ```
 
@@ -130,7 +130,7 @@ If you use the Kafka binder, you can download [http-transformer-with-Kafka-binde
 After downloading and unpacking the source code, you can build the application by using Maven, as follows:
 
 ```
-cd composed-http-transformer-rabbitmq
+cd composed-http-transformer-kafka
 ./mvnw clean install
 ```
 
@@ -247,7 +247,7 @@ If you use the RabbitMQ binder, you can download [http-transformer-kotlin-with-R
 After downloading and unpacking the source code, you can build the application by using Maven, as follows:
 
 ```
-cd composed-http-transformer-kotlin-kafka
+cd composed-http-transformer-kotlin-rabbitmq
 ./mvnw clean install
 ```
 
@@ -255,7 +255,7 @@ If you use the Kafka binder, you can download [http-transformer-kotlin-with-Kafk
 After downloading and unpacking the source code, you can build the application by using Maven, as follows:
 
 ```
-cd composed-http-transformer-kotlin-rabbitmq
+cd composed-http-transformer-kotlin-kafka
 ./mvnw clean install
 ```
 


### PR DESCRIPTION
The author just mistyped therefore I swapped examples

"If you use the RabbitMQ binder, you can download http-transformer-with-RabbitMQ-binder After downloading and unpacking the source code, you can build the application by using Maven, as follows:

cd composed-http-transformer-kafka
./mvnw clean install

If you use the Kafka binder, you can download http-transformer-with-Kafka-binder After downloading and unpacking the source code, you can build the application by using Maven, as follows:

cd composed-http-transformer-rabbitmq
./mvnw clean install"