### PR TITLE
Add bulk import links for 3.0 applications

### DIFF
--- a/cloud-foundry/nginx/conf/includes/redirect.conf
+++ b/cloud-foundry/nginx/conf/includes/redirect.conf
@@ -17,6 +17,11 @@ rewrite ^/rabbitmq-docker-latest$ https://repo.spring.io/libs-release/org/spring
 rewrite ^/kafka-maven-latest$ https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Einstein.SR6/spring-cloud-stream-app-descriptor-Einstein.SR6.stream-apps-kafka-maven redirect;
 rewrite ^/kafka-docker-latest$ https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Einstein.SR6/spring-cloud-stream-app-descriptor-Einstein.SR6.stream-apps-kafka-docker redirect;
 
+rewrite ^/rabbitmq-maven-milestone$ https://repo.spring.io/libs-milestone-local/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0-M1/stream-applications-descriptor-2020.0.0-M1.stream-apps-rabbit-maven redirect;
+rewrite ^/rabbitmq-docker-milestone$ https://repo.spring.io/libs-milestone-local/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0-M1/stream-applications-descriptor-2020.0.0-M1.stream-apps-rabbit-docker redirect;
+rewrite ^/kafka-maven-milestone$ https://repo.spring.io/libs-milestone-local/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0-M1/stream-applications-descriptor-2020.0.0-M1.stream-apps-kafka-maven redirect;
+rewrite ^/kafka-docker-milestone$ https://repo.spring.io/libs-milestone-local/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0-M1/stream-applications-descriptor-2020.0.0-M1.stream-apps-kafka-docker redirect;
+
 rewrite ^/Einstein-SR3-stream-applications-rabbit-maven$ https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Einstein.SR3/spring-cloud-stream-app-descriptor-Einstein.SR3.stream-apps-rabbit-maven redirect;
 rewrite ^/Einstein-SR3-stream-applications-rabbit-docker$ https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Einstein.SR3/spring-cloud-stream-app-descriptor-Einstein.SR3.stream-apps-rabbit-docker redirect;
 rewrite ^/Einstein-SR3-stream-applications-kafka-maven$ https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Einstein.SR3/spring-cloud-stream-app-descriptor-Einstein.SR3.stream-apps-kafka-maven redirect;


### PR DESCRIPTION
The goal is to overwrite the value for this 4 new URIs whenever there's a new milestone release on the 3.0 line. No need to continue to have individual bulk import links for each milestone going forward.