### PR TITLE
Apps links changes

### DIFF
--- a/cloud-foundry/nginx/conf/includes/redirect.conf
+++ b/cloud-foundry/nginx/conf/includes/redirect.conf
@@ -11,15 +11,15 @@ rewrite ^/Dearborn-BUILD-SNAPSHOT-task-applications-maven$ https://repo.spring.i
 rewrite ^/Dearborn-SR1-task-applications-docker$ https://repo1.maven.org/maven2/org/springframework/cloud/task/app/spring-cloud-task-app-descriptor/Dearborn.SR1/spring-cloud-task-app-descriptor-Dearborn.SR1.task-apps-docker redirect;
 rewrite ^/Dearborn-BUILD-SNAPSHOT-task-applications-docker$ https://repo.spring.io/snapshot/org/springframework/cloud/task/app/spring-cloud-task-app-descriptor/Dearborn.BUILD-SNAPSHOT/spring-cloud-task-app-descriptor-Dearborn.BUILD-SNAPSHOT.task-apps-docker redirect;
 
-rewrite ^/rabbitmq-maven-latest$ https://repo.spring.io/release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Einstein.SR9/spring-cloud-stream-app-descriptor-Einstein.SR9.stream-apps-rabbit-maven redirect;
-rewrite ^/rabbitmq-docker-latest$ https://repo.spring.io/release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Einstein.SR9/spring-cloud-stream-app-descriptor-Einstein.SR9.stream-apps-rabbit-docker redirect;
-rewrite ^/kafka-maven-latest$ https://repo.spring.io/release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Einstein.SR9/spring-cloud-stream-app-descriptor-Einstein.SR9.stream-apps-kafka-maven redirect;
-rewrite ^/kafka-docker-latest$ https://repo.spring.io/release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Einstein.SR9/spring-cloud-stream-app-descriptor-Einstein.SR9.stream-apps-kafka-docker redirect;
+rewrite ^/rabbitmq-maven-einstein$ https://repo.spring.io/release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Einstein.SR9/spring-cloud-stream-app-descriptor-Einstein.SR9.stream-apps-rabbit-maven redirect;
+rewrite ^/rabbitmq-docker-einstein$ https://repo.spring.io/release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Einstein.SR9/spring-cloud-stream-app-descriptor-Einstein.SR9.stream-apps-rabbit-docker redirect;
+rewrite ^/kafka-maven-einstein$ https://repo.spring.io/release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Einstein.SR9/spring-cloud-stream-app-descriptor-Einstein.SR9.stream-apps-kafka-maven redirect;
+rewrite ^/kafka-docker-einstein$ https://repo.spring.io/release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Einstein.SR9/spring-cloud-stream-app-descriptor-Einstein.SR9.stream-apps-kafka-docker redirect;
 
-rewrite ^/rabbitmq-maven-latest-v2$ https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0/stream-applications-descriptor-2020.0.0.stream-apps-rabbit-maven redirect;
-rewrite ^/rabbitmq-docker-latest-v2$ https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0/stream-applications-descriptor-2020.0.0.stream-apps-rabbit-docker redirect;
-rewrite ^/kafka-maven-latest-v2$ https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0/stream-applications-descriptor-2020.0.0.stream-apps-kafka-maven redirect;
-rewrite ^/kafka-docker-latest-v2$ https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0/stream-applications-descriptor-2020.0.0.stream-apps-kafka-docker redirect;
+rewrite ^/rabbitmq-maven-latest$ https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0/stream-applications-descriptor-2020.0.0.stream-apps-rabbit-maven redirect;
+rewrite ^/rabbitmq-docker-latest$ https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0/stream-applications-descriptor-2020.0.0.stream-apps-rabbit-docker redirect;
+rewrite ^/kafka-maven-latest$ https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0/stream-applications-descriptor-2020.0.0.stream-apps-kafka-maven redirect;
+rewrite ^/kafka-docker-latest$ https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0/stream-applications-descriptor-2020.0.0.stream-apps-kafka-docker redirect;
 
 rewrite ^/rabbitmq-maven-milestone$ https://repo.spring.io/milestone/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0-RC2/stream-applications-descriptor-2020.0.0-RC2.stream-apps-rabbit-maven redirect;
 rewrite ^/rabbitmq-docker-milestone$ https://repo.spring.io/milestone/org/springframework/cloud/stream/app/stream-applications-descriptor/2020.0.0-RC2/stream-applications-descriptor-2020.0.0-RC2.stream-apps-rabbit-docker redirect;


### PR DESCRIPTION
 - Update the current v2 links (3.0.0 apps/2020.0.0) as the latest.
 - Update the current latest (Einstein) apps to indicate that they
   are part of the Einstein release train by appending "einstein"
   in the link name.