### PR TITLE
Remove dollar prompt from copyable command examples

### DIFF
--- a/content/documentation/pages/3-stream-developer-guides/1-getting-started/1-stream.md
+++ b/content/documentation/pages/3-stream-developer-guides/1-getting-started/1-stream.md
@@ -126,7 +126,7 @@ Once a stream is deployed, you can view its logs. To do so:
     `/path/from/stdout/textbox/in/dashboard` with the value you copied
     in the previous step:
 
-        $ docker exec -it skipper tail -f /path/from/stdout/textbox/in/dashboard
+        docker exec -it skipper tail -f /path/from/stdout/textbox/in/dashboard
 
     The output of the log sink appears in the new window. You should see the output shown below.
 
@@ -153,7 +153,7 @@ curl http://http-ingest-314-log-v1.cfapps.io -H "Content-type: text/plain" -d "H
 Now you can list the running applications again and see your
 applications in the list, as follows:
 
-    $ cf apps                                                                                                                                                                                                                                         [1h] ✭
+    cf apps                                                                                                                                                                                                                                         [1h] ✭
     Getting apps in org ORG / space SPACE as email@pivotal.io...
 
     name                         requested state   instances   memory   disk   urls

--- a/content/documentation/pages/3-stream-developer-guides/2-streams/2-deployment/2-kubernetes.md
+++ b/content/documentation/pages/3-stream-developer-guides/2-streams/2-deployment/2-kubernetes.md
@@ -36,8 +36,8 @@ If you built the apps from scratch using the Boot Maven plugin, the default conf
 Now you can run the Maven build to create the Docker images in the `minikube` Docker registry. To do so, run the following commands:
 
 ```bash
-$ eval $(minikube docker-env)
-$./mvnw spring-boot:build-image
+eval $(minikube docker-env)
+./mvnw spring-boot:build-image
 ```
 
 If you downloaded the project source, the project includes a parent pom to let you build all the modules with a single command.

--- a/content/documentation/pages/4-batch-developer-guides/2-batch/1-simple-task.md
+++ b/content/documentation/pages/4-batch-developer-guides/2-batch/1-simple-task.md
@@ -179,7 +179,7 @@ You can use the use the following commands to query the `TASK_EXECUTION` table:
 
 <!-- Rolling my own to disable erroneous formatting -->
 <div class="gatsby-highlight" data-language="bash">
-<pre class="language-bash"><code>$ docker exec -it mariadb bash -l
+<pre class="language-bash"><code>docker exec -it mariadb bash -l
 # mariadb -u root -ppassword
 MariaDB&gt; select * from task.TASK_EXECUTION;
 </code></pre></div>
@@ -363,7 +363,7 @@ We need a running [Kubernetes cluster](%currentPath%/installation/kubernetes#cre
 To verify that Minikube is running, run the following command (shown with its output):
 
 ```bash
-$ minikube status
+minikube status
 
 host: Running
 kubelet: Running
@@ -454,7 +454,7 @@ kubectl apply -f task-app.yaml
 When the task is complete, you should see output that resembles the following:
 
 ```bash
-$ kubectl get pods
+kubectl get pods
 NAME                     READY   STATUS      RESTARTS   AGE
 mariadb-5cbb6c49f7-ntg2l 1/1     Running     0          4h
 billsetuptask            0/1     Completed   0          81s
@@ -473,7 +473,7 @@ Then you need to log in, as follows:
 
 <!-- Rolling my own to disable erroneous formatting -->
 <div class="gatsby-highlight" data-language="bash">
-<pre class="language-bash"><code>$ kubectl exec -it mariadb-5cbb6c49f7-ntg2l -- /bin/bash
+<pre class="language-bash"><code>kubectl exec -it mariadb-5cbb6c49f7-ntg2l -- /bin/bash
 # mariadb -u root -p$MARIADB_ROOT_PASSWORD
 mariadb&gt; select * from task.TASK_EXECUTION;
 </code></pre></div>

--- a/content/documentation/pages/4-batch-developer-guides/2-batch/2-spring-batch.md
+++ b/content/documentation/pages/4-batch-developer-guides/2-batch/2-spring-batch.md
@@ -309,7 +309,7 @@ Now we can build the project.
 
 <!-- Rolling my own to disable erroneous formating -->
 <div class="gatsby-highlight" data-language="bash">
-<pre class="language-bash"><code>$ docker exec -it mysql bash -l
+<pre class="language-bash"><code>docker exec -it mysql bash -l
 # mysql -u root -ppassword
 mysql&gt; select * from task.BILL_STATEMENTS;
 </code></pre></div>

--- a/content/documentation/pages/4-batch-developer-guides/2-batch/7-data-flow-simple-task-kubernetes.md
+++ b/content/documentation/pages/4-batch-developer-guides/2-batch/7-data-flow-simple-task-kubernetes.md
@@ -20,7 +20,7 @@ When SCDF is running on Kubernetes, you should see the `scdf-server` pod in a `R
 You can use the following command (shown with typical output) to see the `scdf-server`:
 
 ```bash
-$ kubectl get all -l app=scdf-server
+kubectl get all -l app=scdf-server
 NAME                              READY   STATUS    RESTARTS   AGE
 pod/scdf-server-65789665d-79hrz   1/1     Running   0          5m39s
 
@@ -45,15 +45,15 @@ We build the `billsetuptask` app, which is configured with the [jib maven plugin
 1. Run the following commands to build the docker image:
 
    ```bash
-   $ eval $(minikube docker-env)
-   $ ./mvnw clean package jib:dockerBuild
+   eval $(minikube docker-env)
+   ./mvnw clean package jib:dockerBuild
    ```
 
    Those commands add the image to the `minikube` Docker registry.
 
 1. Verify its presence by finding `springcloudtask/billsetuptask` in the list of images provided by running the following command:
    ```bash
-   $ docker images
+   docker images
    ```
 
 ### Registering, Creating, and Launching the Task by Using Data Flow
@@ -63,7 +63,7 @@ We use the `Data Flow Dashboard` to set up and launch the `billsetuptask` applic
 First, we need to get the SCDF Server URL, which we can do with the following command (the listing includes the output):
 
 ```bash
-$ minikube service --url scdf-server
+minikube service --url scdf-server
 http://192.168.99.100:30403
 ```
 

--- a/content/documentation/pages/5-feature-guides/1-general/2-server-monitoring.md
+++ b/content/documentation/pages/5-feature-guides/1-general/2-server-monitoring.md
@@ -79,7 +79,7 @@ The address used to access the Grafana UI depends on the Kubernetes platform to 
 To obtain the URL of the Grafana UI when it is deployed to Minikube, run the following command:
 
 ```bash
-$ minikube service --url grafana
+minikube service --url grafana
 http://192.168.99.100:31595
 ```
 

--- a/content/documentation/pages/5-feature-guides/2-streams/12-monitoring.md
+++ b/content/documentation/pages/5-feature-guides/2-streams/12-monitoring.md
@@ -168,7 +168,7 @@ The address used to access the Grafana UI depends on the Kubernetes platform the
 To obtain the URL of the Grafana UI when it is deployed to Minikube, run the following command:
 
 ```bash
-$ minikube service --url grafana
+minikube service --url grafana
 http://192.168.99.100:31595
 ```
 

--- a/content/documentation/pages/5-feature-guides/3-batch/4-monitoring.md
+++ b/content/documentation/pages/5-feature-guides/3-batch/4-monitoring.md
@@ -250,7 +250,7 @@ The address used to access the Grafana Dashboard depends on the Kubernetes platf
 To obtain the URL of the Grafana UI when it is deployed to Minikube, run the following command:
 
 ```bash
-$ minikube service --url grafana
+minikube service --url grafana
 http://192.168.99.100:31595
 ```
 

--- a/content/documentation/pages/7-recipes/9-cloud-providers/1-gke-regional-clusters.md
+++ b/content/documentation/pages/7-recipes/9-cloud-providers/1-gke-regional-clusters.md
@@ -64,19 +64,19 @@ When the cluster is created, three worker nodes are deployed to each of the thre
 Lastly, the credentials need to be fetched through the `gcloud` CLI so that `kubectl` can interact with the cluster. To do so, run the following command:
 
 ```
-$ gcloud container clusters get-credentials regional-demo --zone us-east1 --project PROJECT_ID
+gcloud container clusters get-credentials regional-demo --zone us-east1 --project PROJECT_ID
 ```
 
 Replace `PROJECT_ID` with your GKE project ID. Additionally, to make it easier to identify the context name, run the following command:
 
 ```
-$ kubectl config rename-context gke_PROJECT_ID_us-east1_regional-demo regional-demo
+kubectl config rename-context gke_PROJECT_ID_us-east1_regional-demo regional-demo
 ```
 
 Verify that the correct current context is set with `kubectl` (indicated by `*`):
 
 ```
-$ kubectl config get-contexts
+kubectl config get-contexts
 CURRENT   NAME            CLUSTER                                                   AUTHINFO                                                  NAMESPACE
 *         regional-demo   gke_PROJECT_ID_us-east1_regional-demo   gke_PROJECT_ID_us-east1_regional-demo
 ```
@@ -86,7 +86,7 @@ CURRENT   NAME            CLUSTER                                               
 Verify that the worker nodes are available:
 
 ```
-$ kubectl get nodes
+kubectl get nodes
 NAME                                           STATUS   ROLES    AGE   VERSION
 gke-regional-demo-default-pool-e121c001-k667   Ready    <none>   13m   v1.16.9-gke.2
 gke-regional-demo-default-pool-e121c001-zhrt   Ready    <none>   13m   v1.16.9-gke.2
@@ -104,7 +104,7 @@ As shown, there are nine nodes, with three in each pool.
 Each node has a label applied by the key of `failure-domain.beta.kubernetes.io/zone` and a value of the zone in which it is located. To identify which nodes are placed in which zones, we can select the label -- for example:
 
 ```
-$ kubectl get nodes -l failure-domain.beta.kubernetes.io/zone=us-east1-b
+kubectl get nodes -l failure-domain.beta.kubernetes.io/zone=us-east1-b
 NAME                                           STATUS   ROLES    AGE   VERSION
 gke-regional-demo-default-pool-ea10f422-5f72   Ready    <none>   29m   v1.16.9-gke.2
 gke-regional-demo-default-pool-ea10f422-ntdk   Ready    <none>   29m   v1.16.9-gke.2
@@ -112,7 +112,7 @@ gke-regional-demo-default-pool-ea10f422-vw3c   Ready    <none>   29m   v1.16.9-g
 ```
 
 ```
-$ kubectl get nodes -l failure-domain.beta.kubernetes.io/zone=us-east1-c
+kubectl get nodes -l failure-domain.beta.kubernetes.io/zone=us-east1-c
 NAME                                           STATUS   ROLES    AGE   VERSION
 gke-regional-demo-default-pool-e121c001-k667   Ready    <none>   29m   v1.16.9-gke.2
 gke-regional-demo-default-pool-e121c001-zhrt   Ready    <none>   29m   v1.16.9-gke.2
@@ -120,7 +120,7 @@ gke-regional-demo-default-pool-e121c001-zpv4   Ready    <none>   29m   v1.16.9-g
 ```
 
 ```
-$ kubectl get nodes -l failure-domain.beta.kubernetes.io/zone=us-east1-d
+kubectl get nodes -l failure-domain.beta.kubernetes.io/zone=us-east1-d
 NAME                                           STATUS   ROLES    AGE   VERSION
 gke-regional-demo-default-pool-fb3e6608-0lx2   Ready    <none>   29m   v1.16.9-gke.2
 gke-regional-demo-default-pool-fb3e6608-0rcc   Ready    <none>   29m   v1.16.9-gke.2
@@ -157,7 +157,7 @@ A default `StorageClass`, which we use for simplicity, is automatically created 
 Deploy the manifests:
 
 ```
-$ kubectl create -f mysql/
+kubectl create -f mysql/
 deployment.apps/mysql created
 persistentvolumeclaim/mysql created
 secret/mysql created
@@ -167,7 +167,7 @@ service/mysql created
 Get the volume name:
 
 ```
-$ kubectl get pvc/mysql
+kubectl get pvc/mysql
 NAME    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
 mysql   Bound    pvc-24f2acb5-17cd-45e1-8064-34bf602e408f   8Gi        RWO            standard       3m1s
 ```
@@ -175,14 +175,14 @@ mysql   Bound    pvc-24f2acb5-17cd-45e1-8064-34bf602e408f   8Gi        RWO      
 Check the zone in which the volume is located:
 
 ```
-$ kubectl get pv/pvc-24f2acb5-17cd-45e1-8064-34bf602e408f -o jsonpath='{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}'
+kubectl get pv/pvc-24f2acb5-17cd-45e1-8064-34bf602e408f -o jsonpath='{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}'
 us-east1-d
 ```
 
 Check the MySQL pod to verify it is running and the node to which it is allocated:
 
 ```
-$ kubectl get pod/mysql-b94654bd4-9zpt2 -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName
+kubectl get pod/mysql-b94654bd4-9zpt2 -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName
 NAME                    STATUS    NODE
 mysql-b94654bd4-9zpt2   Running   gke-regional-demo-default-pool-fb3e6608-0rcc
 ```
@@ -190,7 +190,7 @@ mysql-b94654bd4-9zpt2   Running   gke-regional-demo-default-pool-fb3e6608-0rcc
 Finally, verify the zone in which the node resides:
 
 ```
-$ kubectl get node gke-regional-demo-default-pool-fb3e6608-0rcc -o jsonpath='{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}'
+kubectl get node gke-regional-demo-default-pool-fb3e6608-0rcc -o jsonpath='{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}'
 us-east1-d
 ```
 
@@ -217,7 +217,7 @@ To place RabbitMQ on a node in the `us-east1-b` zone, make the following modific
 Deploy the manifests:
 
 ```
-$ kubectl create -f rabbitmq/
+kubectl create -f rabbitmq/
 deployment.apps/rabbitmq created
 service/rabbitmq created
 ```
@@ -225,14 +225,14 @@ service/rabbitmq created
 Get the node to which the pod is deployed:
 
 ```
-$ kubectl get pod/rabbitmq-6d65f675d9-4vksj -o jsonpath='{.spec.nodeName}'
+kubectl get pod/rabbitmq-6d65f675d9-4vksj -o jsonpath='{.spec.nodeName}'
 gke-regional-demo-default-pool-ea10f422-5f72
 ```
 
 Get the zone in which the node resides:
 
 ```
-$ kubectl get node gke-regional-demo-default-pool-ea10f422-5f72 -o jsonpath='{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}'
+kubectl get node gke-regional-demo-default-pool-ea10f422-5f72 -o jsonpath='{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}'
 us-east1-b
 ```
 
@@ -264,18 +264,18 @@ spec:
 Deploy the manifests:
 
 ```
-$ kubectl create -f server/server-roles.yaml
-$ kubectl create -f server/server-rolebinding.yaml
-$ kubectl create -f server/service-account.yaml
-$ kubectl create -f skipper/skipper-config-rabbit.yaml
-$ kubectl create -f skipper/skipper-deployment.yaml
-$ kubectl create -f skipper/skipper-svc.yaml
+kubectl create -f server/server-roles.yaml
+kubectl create -f server/server-rolebinding.yaml
+kubectl create -f server/service-account.yaml
+kubectl create -f skipper/skipper-config-rabbit.yaml
+kubectl create -f skipper/skipper-deployment.yaml
+kubectl create -f skipper/skipper-svc.yaml
 ```
 
 Get the nodes to which the pods are deployed:
 
 ```
-$ kubectl get pods -l app=skipper -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName
+kubectl get pods -l app=skipper -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName
 NAME                       STATUS    NODE
 skipper-6fd7bb796c-flm44   Running   gke-regional-demo-default-pool-e121c001-zhrt
 skipper-6fd7bb796c-l99dj   Running   gke-regional-demo-default-pool-ea10f422-5f72
@@ -285,11 +285,11 @@ skipper-6fd7bb796c-vrf9m   Running   gke-regional-demo-default-pool-fb3e6608-0lx
 Get the zones in which the nodes reside:
 
 ```
-$ kubectl get node gke-regional-demo-default-pool-e121c001-zhrt -o jsonpath='{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}'
+kubectl get node gke-regional-demo-default-pool-e121c001-zhrt -o jsonpath='{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}'
 us-east1-c
-$ kubectl get node gke-regional-demo-default-pool-ea10f422-5f72 -o jsonpath='{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}'
+kubectl get node gke-regional-demo-default-pool-ea10f422-5f72 -o jsonpath='{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}'
 us-east1-b
-$ kubectl get node gke-regional-demo-default-pool-fb3e6608-0lx2 -o jsonpath='{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}'
+kubectl get node gke-regional-demo-default-pool-fb3e6608-0lx2 -o jsonpath='{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}'
 us-east1-d
 ```
 
@@ -320,15 +320,15 @@ spec:
 Deploy the manifests:
 
 ```
-$ kubectl create -f server/server-config.yaml
-$ kubectl create -f server/server-svc.yaml
-$ kubectl create -f server/server-deployment.yaml
+kubectl create -f server/server-config.yaml
+kubectl create -f server/server-svc.yaml
+kubectl create -f server/server-deployment.yaml
 ```
 
 Get the nodes to which the pods are deployed:
 
 ```
-$ kubectl get pods -l app=scdf-server -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName
+kubectl get pods -l app=scdf-server -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName
 NAME                           STATUS    NODE
 scdf-server-5ddf7bbd4f-dpnmm   Running   gke-regional-demo-default-pool-fb3e6608-0lx2
 scdf-server-5ddf7bbd4f-hlf9h   Running   gke-regional-demo-default-pool-e121c001-zhrt
@@ -338,7 +338,7 @@ scdf-server-5ddf7bbd4f-vnjh6   Running   gke-regional-demo-default-pool-ea10f422
 Verify that the pods are deployed to the same nodes as Skipper:
 
 ```
-$ kubectl get pods -l app=skipper -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName
+kubectl get pods -l app=skipper -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName
 NAME                       STATUS    NODE
 skipper-6fd7bb796c-flm44   Running   gke-regional-demo-default-pool-e121c001-zhrt
 skipper-6fd7bb796c-l99dj   Running   gke-regional-demo-default-pool-ea10f422-5f72
@@ -348,8 +348,8 @@ skipper-6fd7bb796c-vrf9m   Running   gke-regional-demo-default-pool-fb3e6608-0lx
 Verify the connectivity to Data Flow:
 
 ```
-$ SCDF_IP=$(kubectl get svc/scdf-server -o jsonpath='{.status.loadBalancer.ingress[*].ip}')
-$ curl -s http://$SCDF_IP/about | jq
+SCDF_IP=$(kubectl get svc/scdf-server -o jsonpath='{.status.loadBalancer.ingress[*].ip}')
+curl -s http://$SCDF_IP/about | jq
 {
   "featureInfo": {
     "analyticsEnabled": true,

--- a/content/documentation/pages/9-applications/4-application-metadata.md
+++ b/content/documentation/pages/9-applications/4-application-metadata.md
@@ -120,7 +120,7 @@ NOTE The Cloud Native [buildpack for spring-boot](https://github.com/paketo-buil
 For the uber-jar packaged applications, the plugin will create a companion artifact that contains the metadata. Specifically, it contains the Spring boot JSON file about configuration properties metadata and the dataflow configuration metadata file described in the previous section. The following example shows the contents of such an artifact, for the canonical log sink:
 
 ```shell
-$ jar tvf log-sink-rabbit-3.0.0.BUILD-SNAPSHOT-metadata.jar
+jar tvf log-sink-rabbit-3.0.0.BUILD-SNAPSHOT-metadata.jar
 373848 META-INF/spring-configuration-metadata.json
    174 META-INF/dataflow-configuration-metadata.properties
 ```


### PR DESCRIPTION
This removes the `$` from the copyable command examples in the microsite. 

ℹ️ This https://github.com/bitnami/charts/pull/8631 handles the remaining 4 copyable command examples as it is included via
```
<!--TEMPLATE:https://raw.githubusercontent.com/bitnami/charts/master/bitnami/spring-cloud-dataflow/README.md-->
```

Resolves gh-280