### PR TITLE
Provide a not in documentation about setting table prefix for JobRepository and Explorer

### DIFF
--- a/content/documentation/pages/4-batch-developer-guides/2-batch/4-data-flow-spring-batch.md
+++ b/content/documentation/pages/4-batch-developer-guides/2-batch/4-data-flow-spring-batch.md
@@ -152,6 +152,13 @@ To launch a task:
    When the execution is complete, the Status turns to a green color and shows `Complete.`
    Select the **Executions** tab to view a summary of executions for this task.
 
+<!--NOTE-->
+
+When creating a Spring Batch 5.x+ application with the `@EnableBatchProcessing` annotation and your app requires that you
+set the `TablePrefix`, remember that you must also set it for the `JobRepository` and `JobExplorer` beans.
+
+<!--END_NOTE-->
+
 ![Task executions](images/SCDF-batch-executions.png)
 
 ### Reviewing the Job Execution


### PR DESCRIPTION
When using the @EnableBatchProcessing annotation in a batch app and the user wants to have a table prefix, they must first set the prefix on the JobRepository and JobExplorers they plan to use.

Resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/5848