### PR TITLE
Add Windows support for Java 17 setup in local installation doc

### DIFF
--- a/content/documentation/pages/1-installation/1-local/1-docker.md
+++ b/content/documentation/pages/1-installation/1-local/1-docker.md
@@ -297,9 +297,27 @@ To learn more about the monitoring experience in Spring Cloud Data Flow with Pro
 
 Currently Spring Cloud Data Flow defaults to Java 8 when running applications. If you wish to run Java 17 applications set the `BP_JVM_VERSION` to `-jdk17` as shown below:
 
+<!--TABS-->
+
+<!--Linux / OSX-->
+
 ```bash
 export BP_JVM_VERSION=-jdk17
 ```
+
+<!--Windows (Cmd)-->
+
+```bash
+set BP_JVM_VERSION=-jdk17
+```
+
+<!--Windows (PowerShell) -->
+
+```bash
+$Env:BP_JVM_VERSION="-jdk17"
+```
+
+<!--END_TABS-->
 
 ## Debugging
 


### PR DESCRIPTION
I added Windows configuration instructions to the 'Running Java 17 Applications' section of the documentation, as it seemed to be missing.
Please let me know if there are any issues. Thank you:)